### PR TITLE
[FIX] changed default solver from CPLEX to GUROBI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Can be easily installed using **pip**:
 pip install carveme
 ```
 
-Additionally, you must install diamond and CPLEX (please check the documentation for details). 
+Additionally, you must install diamond and GUROBI:
+
+    - https://github.com/bbuchfink/diamond
+    
+    - https://www.gurobi.com/academia/academic-program-and-licenses/
+
 
 ### Credits and License
 

--- a/carveme/config.cfg
+++ b/carveme/config.cfg
@@ -21,7 +21,7 @@ default_universe = data/generated/universe_bacteria.xml.gz
 bigg_gibbs = data/generated/bigg_gibbs.csv
 
 [solver]
-default_solver = cplex
+default_solver = gurobi
 feas_tol = 1e-9
 opt_tol = 1e-9
 int_feas_tol = 1e-5


### PR DESCRIPTION
Should fix Issue #55 

Changed carveme/config.cfg to take gurobi as default solver.

Changed README.md to indicate that GUROBI must be installed instead of CPLEX.