### PR TITLE
fix: universe extensions in gapfill.py

### DIFF
--- a/carveme/cli/gapfill.py
+++ b/carveme/cli/gapfill.py
@@ -33,7 +33,7 @@ def maincall(inputfile, media, mediadb=None, universe=None, universe_file=None, 
 
     if not universe_file:
         if universe:
-            universe_file = "{}{}universe_{}.xml".format(project_dir, config.get('generated', 'folder'), universe)
+            universe_file = "{}{}universe_{}.xml.gz".format(project_dir, config.get('generated', 'folder'), universe)
         else:
             universe_file = project_dir + config.get('generated', 'default_universe')
 


### PR DESCRIPTION
Hi! I was trying to use `gapfill` as a standalone function for a model, but I kept getting `OSError: Failed to load universe`, in spite of using a standard universe like "grampos". After some digging, I discovered that in commit [`cd57c56`](https://github.com/cdanielmachado/carveme/commit/cd57c566773d67d2d6615f3d4373d99a1099cb74) the `carve` script was adapted to read the `.xml.gz` universe files instead of the `.xml` ones (the latter which were deleted in the same commit); however, `gapfill` was not adapted in the same way, which makes it unable to find the universe files. This PR fixes that.

