### PR TITLE
Fix greedy cpu allocation

### DIFF
--- a/carveme/__init__.py
+++ b/carveme/__init__.py
@@ -9,11 +9,6 @@ __version__ = '1.6.2'
 project_dir = os.path.abspath(os.path.dirname(__file__)) + '/'
 
 config = ConfigParser()
-config.read(project_dir + 'config.cfg')
-for k,v in config.items():
-    if os.pathsep in v:
-        if not os.path.exists(v):
-            raise ValueError(f'file {v} not found')
 
 #set_default_solver(config.get('solver', 'default_solver'))
 #default_parameters[Parameter.FEASIBILITY_TOL] = config.getfloat('solver', 'feas_tol')

--- a/carveme/__init__.py
+++ b/carveme/__init__.py
@@ -9,6 +9,7 @@ __version__ = '1.6.2'
 project_dir = os.path.abspath(os.path.dirname(__file__)) + '/'
 
 config = ConfigParser()
+config.read(project_dir + 'config.cfg')
 
 #set_default_solver(config.get('solver', 'default_solver'))
 #default_parameters[Parameter.FEASIBILITY_TOL] = config.getfloat('solver', 'feas_tol')

--- a/carveme/__init__.py
+++ b/carveme/__init__.py
@@ -10,6 +10,10 @@ project_dir = os.path.abspath(os.path.dirname(__file__)) + '/'
 
 config = ConfigParser()
 config.read(project_dir + 'config.cfg')
+for k,v in config.items():
+    if os.pathsep in v:
+        if not os.path.exists(v):
+            raise ValueError(f'file {v} not found')
 
 #set_default_solver(config.get('solver', 'default_solver'))
 #default_parameters[Parameter.FEASIBILITY_TOL] = config.getfloat('solver', 'feas_tol')

--- a/carveme/cli/carve.py
+++ b/carveme/cli/carve.py
@@ -25,7 +25,7 @@ def first_run_check(ncores):
     if not os.path.exists(diamond_db):
         print("Running diamond for the first time, please wait while we build the internal database...")
         fasta_file = project_dir + config.get('generated', 'fasta_file')
-        cmd = ['diamond', 'makedb', '--threads', ncores,  '--in', fasta_file, '-d', diamond_db[:-5]]
+        cmd = ['diamond', 'makedb', '--threads', str(ncores),  '--in', fasta_file, '-d', diamond_db[:-5]]
         try:
             exit_code = subprocess.call(cmd)
         except OSError:

--- a/carveme/config.cfg
+++ b/carveme/config.cfg
@@ -1,7 +1,6 @@
 [input]
 biomass_library = data/input/biomass_db.tsv
 media_library = data/input/media_db.tsv
-metabolomics = data/input/metabolomics_park2016.csv
 refseq = data/input/refseq_release_201.tsv.gz
 mnx_compounds = data/input/mnx_compounds.tsv
 bigg_models = data/input/bigg_models.tsv
@@ -14,7 +13,6 @@ bigg_gprs = data/generated/bigg_gprs.csv.gz
 model_specific_data = data/generated/model_specific_data.csv.gz
 gene_annotations = data/generated/gene_annotations.tsv.gz
 bigg_universe = data/generated/bigg_universe.xml.gz
-bigg_annotated = data/generated/bigg_annotated.xml.gz
 default_universe = data/generated/universe_bacteria.xml.gz
 fasta_file = data/generated/bigg_proteins.faa
 diamond_db = data/generated/bigg_proteins.dmnd
@@ -35,4 +33,3 @@ default_flavor = bigg
 
 [gapfill]
 max_uptake = 100
-

--- a/carveme/reconstruction/diamond.py
+++ b/carveme/reconstruction/diamond.py
@@ -25,7 +25,7 @@ def load_diamond_results(filename, drop_unused_cols=True):
     return data
 
 
-def run_blast(inputfile, input_type, outputfile, database, args=None, verbose=True):
+def run_blast(inputfile, input_type, outputfile, database, args=None, ncores=None, verbose=True):
     """ Run blast aligment with Diamond.
 
     Args:
@@ -58,7 +58,7 @@ def run_blast(inputfile, input_type, outputfile, database, args=None, verbose=Tr
     cmd += ['-o', outputfile]
 
     if not args:
-        args = "--more-sensitive --top 10 --quiet"
+        args = f"--more-sensitive --top 10 --quiet --threads {ncores}"
 
     cmd += args.split()
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,6 +64,15 @@ This can be combined with *-o* to change the output folder:
 
     $ carve -r myfolder/*.faa -o mymodels/
 
+To balance the number of concurrent samples run  versus the number of cores allocated to each ,
+specify the `--njobs` and `--ncores` argument.  `--njobs` gets passed to `multiprocessing.Pool()`,
+ while `--ncores` gets passed to Diamond. these default to running in single-threaded mode for all available CPUs.
+ To instead run Diamond with 4 threads on a maximum of 2 concurrent samples, this be adjusted to :
+
+.. code-block:: console
+
+    $ carve --ncores 4 --njobs 2 -r myfolder/*.faa -o mymodels/
+
 
 Gap Filling
 -----------
@@ -152,5 +161,3 @@ You can initialize the community with a pre-defined medium (just like during sin
 .. code-block:: console
 
     $ merge_community [input files] -i M9
-
-

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """The setup script."""
-
+import os
+from configparser import ConfigParser
 from setuptools import setup, find_packages
 
 with open('README.rst') as readme_file:
@@ -79,6 +80,16 @@ if missing_files:
     print("files required for install are not found:\n")
     print("\n".join(missing_files))
     raise ValueError("missing files; exiting")
+
+config = ConfigParser()
+project_dir = "carveme"
+config.read(os.path.join(project_dir, 'config.cfg'))
+for chunk in ["input", "generated"]:
+    for k,v in config[chunk].items():
+        vpath = os.path.join(project_dir, v)
+        if not os.path.exists(vpath) and k != "diamond_db":
+            raise ValueError(f'file {vpath} not found')
+
 
 setup(
     name='carveme',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ included_files = {
         'data/input/media_db.tsv',
         'data/input/metabolomics_park2016.csv',
         'data/input/unbalanced_metabolites.csv',
-        'data/input/bigg_proteins.faa',
+        'data/generated/bigg_proteins.faa',
         'data/input/equilibrator_compounds.tsv.gz',
         'data/input/refseq_release_201.tsv.gz',
         'data/generated/bigg_gibbs.csv',
@@ -100,7 +100,7 @@ setup(
     keywords='carveme',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Environment :: Console', 
+        'Environment :: Console',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,19 @@ requirements = [
 included_files = {
     'carveme': [
         'config.cfg',
-        'data/input/bigg_models.csv',
+        'data/input/bigg_models.tsv',
         'data/input/biomass_db.tsv',
-        'data/input/manually_curated.csv',
+        'data/input/manually_curated.tsv',
         'data/input/media_db.tsv',
-        'data/input/metabolomics_park2016.csv',
+#        'data/input/metabolomics_park2016.csv', deleted 5cbc611af5aa265c39882f7a88bf357f3261b170
         'data/input/unbalanced_metabolites.csv',
         'data/generated/bigg_proteins.faa',
-        'data/input/equilibrator_compounds.tsv.gz',
+        'data/input/mnx_compounds.tsv',
         'data/input/refseq_release_201.tsv.gz',
-        'data/generated/bigg_gibbs.csv',
+#        'data/generated/bigg_gibbs.csv', # deleted c897f41d7d03c27ca12ecd9ee97337355338c378
         'data/generated/bigg_gprs.csv.gz',
         'data/generated/model_specific_data.csv.gz',
-        'data/generated/universe_draft.xml.gz',
+        'data/generated/bigg_universe.xml.gz',
         'data/generated/universe_bacteria.xml.gz',
         'data/generated/universe_grampos.xml.gz',
         'data/generated/universe_gramneg.xml.gz',
@@ -70,7 +70,15 @@ included_files = {
         'data/benchmark/results/essentiality.tsv',
     ]
 }
-
+missing_files = []
+for path in included_files["carveme"]:
+    fullpath = os.path.join("carveme", path)
+    if not os.path.exists(fullpath):
+        missing_files.append(fullpath)
+if missing_files:
+    print("files required for install are not found:\n")
+    print("\n".join(missing_files))
+    raise ValueError("missing files; exiting")
 
 setup(
     name='carveme',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ included_files = {
         'data/generated/bigg_proteins.faa',
         'data/input/mnx_compounds.tsv',
         'data/input/refseq_release_201.tsv.gz',
+        'data/generated/gene_annotations.tsv.gz',
 #        'data/generated/bigg_gibbs.csv', # deleted c897f41d7d03c27ca12ecd9ee97337355338c378
         'data/generated/bigg_gprs.csv.gz',
         'data/generated/model_specific_data.csv.gz',
@@ -84,11 +85,18 @@ if missing_files:
 config = ConfigParser()
 project_dir = "carveme"
 config.read(os.path.join(project_dir, 'config.cfg'))
+config_files = []
 for chunk in ["input", "generated"]:
     for k,v in config[chunk].items():
         vpath = os.path.join(project_dir, v)
-        if not os.path.exists(vpath) and k != "diamond_db":
+        if k in ["folder", "diamond_db"]: continue
+        if not os.path.exists(vpath):
             raise ValueError(f'file {vpath} not found')
+        elif v not in included_files["carveme"]:
+            raise ValueError(f'config file {vpath} not included in setup.py')
+        else:
+            config_files.append(v)
+
 
 
 setup(


### PR DESCRIPTION
Hello! I am trying to use carveme on a compute cluster, and two processes (multiprocessing.Pool() and diamond under the hood) default to using all available cores. As-is, I can't tell carveme to limit the resource usage. This PR adds 2 CLI args -- one for the number of multiprocessing jobs to create and another for the number of cores that each job can use.  The default is to run one single-core job for each available CPU.

Happy to make any changes and discuss!

Thanks,

Nick