### PR TITLE
Add a StrainDesign backend for gap-filling

### DIFF
--- a/bench_gapfill.py
+++ b/bench_gapfill.py
@@ -1,0 +1,48 @@
+"""Real-scale gap-fill: a CarveMe model against the bacterial universe, both backends.
+
+The toy case measured process warm-up, not the algorithm. Here the merged model carries the
+full universe, which is the regime where compression could matter -- or not, if the MILP is
+so easy that no backend helps.
+"""
+import warnings, logging, time, sys
+warnings.filterwarnings('ignore'); logging.disable(logging.WARNING)
+from reframed import load_cbmodel
+from reframed.core.environment import Environment
+from carveme.reconstruction.gapfilling import gapFill
+
+ORG = sys.argv[1] if len(sys.argv) > 1 else 'ecol'
+UNI = 'carveme/data/generated/universe_bacteria.xml.gz'
+
+def fresh():
+    m = load_cbmodel(f'carveme/data/benchmark/models/{ORG}.xml', flavor='bigg')
+    u = load_cbmodel(UNI, flavor='bigg')
+    return m, u
+
+m0, u0 = fresh()
+print(f'MODEL {ORG}: {len(m0.reactions)} rxns | universe {len(u0.reactions)} rxns | '
+      f'candidates {len(set(u0.reactions) - set(m0.reactions))}', flush=True)
+
+# a minimal-ish medium: glucose aerobic, plus the model's own exchange set closed
+compounds = ['glc__D', 'o2', 'nh4', 'pi', 'so4', 'h2o', 'h', 'k', 'mg2', 'fe2', 'ca2', 'cl', 'na1']
+results = {}
+for backend in ('reframed', 'straindesign'):
+    model, uni = fresh()
+    env = Environment.from_compounds(compounds, max_uptake=10)
+    merged_probe = model                      # constraints are applied to the merged model
+    constraints = {r: b for r, b in dict(env).items()}
+    t0 = time.time()
+    try:
+        out = gapFill(model, uni, constraints=constraints, min_growth=0.05,
+                      inplace=False, backend=backend)
+        wall = time.time() - t0
+        added = sorted(set(out.reactions) - set(m0.reactions))
+        results[backend] = (wall, added)
+        print(f'GF {backend:13s} wall={wall:8.1f}s added={len(added)} reactions', flush=True)
+    except Exception as e:
+        print(f'GF {backend:13s} FAILED after {time.time()-t0:.1f}s: {type(e).__name__}: {str(e)[:160]}', flush=True)
+
+if len(results) == 2:
+    a, b = results['reframed'][1], results['straindesign'][1]
+    print(f'CMP identical={a == b} | reframed {len(a)} vs SD {len(b)} | '
+          f'only-reframed {len(set(a)-set(b))} only-SD {len(set(b)-set(a))}', flush=True)
+    print(f'CMP speed: SD x{results["straindesign"][0]/max(0.01,results["reframed"][0]):.2f} vs reframed', flush=True)

--- a/bench_gapfill2.py
+++ b/bench_gapfill2.py
@@ -1,0 +1,48 @@
+"""Gap-filling with real gaps: knock reactions out of a working model, then restore growth.
+
+The previous run was vacuous -- the model already grew, so nothing was added and the MILP was
+trivial. Removing k reactions that the model needs creates a controlled difficulty knob and
+forces the solver to actually search.
+"""
+import warnings, logging, time, sys, random
+warnings.filterwarnings('ignore'); logging.disable(logging.WARNING)
+from reframed import load_cbmodel, FBA
+from reframed.core.environment import Environment
+from carveme.reconstruction.gapfilling import gapFill
+
+ORG = sys.argv[1] if len(sys.argv) > 1 else 'ecol'
+KS = [int(x) for x in (sys.argv[2] if len(sys.argv) > 2 else '5,20').split(',')]
+UNI = 'carveme/data/generated/universe_bacteria.xml.gz'
+COMPOUNDS = ['glc__D', 'o2', 'nh4', 'pi', 'so4', 'h2o', 'h', 'k', 'mg2', 'fe2', 'ca2', 'cl', 'na1']
+CONSTR = dict(Environment.from_compounds(COMPOUNDS, max_uptake=10))
+
+def load(): return load_cbmodel(f'carveme/data/benchmark/models/{ORG}.xml', flavor='bigg')
+
+base = load()
+sol = FBA(base, constraints=CONSTR)
+print(f'MODEL {ORG}: {len(base.reactions)} rxns, wild-type growth={sol.fobj:.4f}', flush=True)
+
+# pick reactions whose removal actually kills growth, so the gap is real
+rng = random.Random(1)
+carrying = [r for r, v in sol.values.items() if abs(v) > 1e-9 and not r.startswith('R_EX')]
+rng.shuffle(carrying)
+
+for k in KS:
+    removed = carrying[:k]
+    for backend in ('reframed', 'straindesign'):
+        model = load()
+        model.remove_reactions(removed)
+        g = FBA(model, constraints=CONSTR)
+        pre = g.fobj if g.fobj else 0.0
+        uni = load_cbmodel(UNI, flavor='bigg')
+        t0 = time.time()
+        try:
+            out = gapFill(model, uni, constraints=CONSTR, min_growth=0.05,
+                          inplace=False, backend=backend)
+            wall = time.time() - t0
+            added = sorted(set(out.reactions) - (set(load().reactions) - set(removed)))
+            print(f'GAP k={k:3d} {backend:13s} pre_growth={pre:.4f} wall={wall:8.1f}s '
+                  f'added={len(added)}', flush=True)
+        except Exception as e:
+            print(f'GAP k={k:3d} {backend:13s} FAILED {time.time()-t0:.1f}s '
+                  f'{type(e).__name__}: {str(e)[:120]}', flush=True)

--- a/carveme/cli/carve.py
+++ b/carveme/cli/carve.py
@@ -325,6 +325,12 @@ def main():
     if args.gapfill and args.ensemble:
         parser.error('Gap fill and ensemble generation cannot currently be combined (not implemented yet).')
 
+    if args.ensemble and args.backend != 'reframed':
+        # build_ensemble goes straight to the carving MILP, so the requested backend would be
+        # ignored without a word and the ensemble built by carving after all.
+        parser.error('Ensemble generation is only implemented for the carving backend '
+                     '(--backend reframed).')
+
     if (args.soft or args.hard) and args.ensemble:
         parser.error('Soft/hard constraints and ensemble generation cannot currently be combined (not implemented yet).')
 

--- a/carveme/cli/carve.py
+++ b/carveme/cli/carve.py
@@ -44,6 +44,7 @@ def build_model_id(name):
 
 def maincall(inputfile, input_type='protein', outputfile=None, diamond_args=None, universe=None, universe_file=None,
          ensemble_size=None, verbose=False, debug=False, flavor=None, gapfill=None, blind_gapfill=False, init=None,
+         backend='reframed',
          mediadb=None, default_score=None, uptake_score=None, soft_score=None, soft=None, hard=None, reference=None,
          ref_score=None, recursive_mode=False):
 
@@ -204,7 +205,8 @@ def maincall(inputfile, input_type='protein', outputfile=None, diamond_args=None
         model = carve_model(universe_model, scores, inplace=(not gapfill), default_score=default_score,
                             uptake_score=uptake_score, soft_score=soft_score, soft_constraints=soft_constraints,
                             hard_constraints=hard_constraints, ref_model=ref_model, ref_score=ref_score,
-                            init_env=init_env, debug_output=debug_output, verbose=verbose)
+                            init_env=init_env, debug_output=debug_output, verbose=verbose,
+                            backend=backend, gprs=gprs, solver=solver)
         annotate_genes(model, gene2gene, gene_annotations)
 
     else:
@@ -305,6 +307,11 @@ def main():
     parser.add_argument('--reference', help="Manually curated model of a close reference species.")
 
     parser.add_argument('--solver', help="Select MILP solver. Available options: cplex [default], gurobi.")
+    parser.add_argument('--backend', choices=['reframed', 'straindesign'], default='reframed',
+                        help="Reconstruction backend. 'reframed' carves the universe down "
+                             "[default]; 'straindesign' completes an annotated core instead, "
+                             "which guarantees no reaction in the result is blocked and that "
+                             "every annotated reaction it keeps carries flux.")
 
     parser.add_argument('--default-score', type=float, default=-1.0, help=argparse.SUPPRESS)
     parser.add_argument('--uptake-score', type=float, default=0.0, help=argparse.SUPPRESS)
@@ -369,6 +376,7 @@ def main():
             flavor=flavor,
             gapfill=args.gapfill,
             blind_gapfill=False,
+            backend=args.backend,
             init=args.init,
             mediadb=args.mediadb,
             default_score=args.default_score,
@@ -395,6 +403,7 @@ def main():
                 flavor=flavor,
                 gapfill=args.gapfill,
                 blind_gapfill=False,
+                backend=args.backend,
                 init=args.init,
                 mediadb=args.mediadb,
                 default_score=args.default_score,

--- a/carveme/reconstruction/carving.py
+++ b/carveme/reconstruction/carving.py
@@ -188,7 +188,8 @@ def minmax_reduction(model, scores, min_growth=0.1, min_atpm=0.1, eps=1e-3, bigM
 
 def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake_score=0.0, soft_score=1.0,
                 soft_constraints=None, hard_constraints=None, ref_model=None, ref_score=0.0, init_env=None,
-                debug_output=None, verbose=False):
+                debug_output=None, verbose=False, backend='reframed', gprs=None, solver=None,
+                threads=None, time_limit=None, min_growth=0.1):
     """ Reconstruct a metabolic model using the CarveMe approach.
 
     Args:
@@ -203,6 +204,14 @@ def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake
         soft_constraints (dict): dictionary from reaction id to expected flux direction (-1, 1, 0)
         hard_constraints (dict): dictionary of flux bounds
         init_env (Environment): initialize final model with given Environment (optional)
+        backend (str): 'reframed' for the carving MILP (default), or 'straindesign' to pose the
+            problem as a completion instead. Completion guarantees that no reaction in the
+            result is blocked and that every annotated reaction it keeps carries flux; carving
+            guarantees neither. It needs a MILP solver via StrainDesign.
+        gprs (pandas.DataFrame): the BiGG GPR table; the completion backend uses it to tell
+            spontaneous reactions from catalysed ones
+        solver (str): MILP solver for the completion backend
+        threads (int), time_limit (float), min_growth (float): completion backend settings
 
     Returns:
         CBModel: reconstructed model
@@ -230,15 +239,22 @@ def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake
     else:
         ref_reactions = None
 
-    sol = minmax_reduction(model, scores, default_score=default_score, uptake_score=uptake_score, soft_score=soft_score,
-                           soft_constraints=soft_constraints, hard_constraints=hard_constraints,
-                           ref_reactions=ref_reactions, ref_score=ref_score, debug_output=debug_output)
-
-    if sol.status == Status.OPTIMAL or sol.status == Status.SUBOPTIMAL:
-        inactive = inactive_reactions(model, sol)
+    if backend == 'straindesign':
+        from carveme.reconstruction.straindesign_backend import complete_model
+        inactive = complete_model(model, reaction_scores, gprs=gprs, min_growth=min_growth,
+                                  constraints=hard_constraints, solver=solver, threads=threads,
+                                  time_limit=time_limit, verbose=verbose)
+        sol = None
     else:
-        print("MILP solver failed: {}".format(sol.message))
-        return
+        sol = minmax_reduction(model, scores, default_score=default_score, uptake_score=uptake_score, soft_score=soft_score,
+                               soft_constraints=soft_constraints, hard_constraints=hard_constraints,
+                               ref_reactions=ref_reactions, ref_score=ref_score, debug_output=debug_output)
+
+        if sol.status == Status.OPTIMAL or sol.status == Status.SUBOPTIMAL:
+            inactive = inactive_reactions(model, sol)
+        else:
+            print("MILP solver failed: {}".format(sol.message))
+            return
 
     if verbose:
         pos_score = {r_id for r_id, val in scores.items() if val > 0}
@@ -252,7 +268,7 @@ def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake
         print(f'AI: {n_ai:4n} AE: {n_ae:4n}')
         print(f'NI: {n_ni:4n} NE: {n_ne:4n}')
 
-    if debug_output:
+    if debug_output and sol is not None:
         pd.DataFrame.from_dict(sol.values, orient='index').to_csv(debug_output + '_milp_solution.tsv',
                                                                   sep='\t', header=False)
 

--- a/carveme/reconstruction/carving.py
+++ b/carveme/reconstruction/carving.py
@@ -189,7 +189,8 @@ def minmax_reduction(model, scores, min_growth=0.1, min_atpm=0.1, eps=1e-3, bigM
 def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake_score=0.0, soft_score=1.0,
                 soft_constraints=None, hard_constraints=None, ref_model=None, ref_score=0.0, init_env=None,
                 debug_output=None, verbose=False, backend='reframed', gprs=None, solver=None,
-                threads=None, time_limit=None, min_growth=0.1):
+                threads=None, time_limit=None, min_growth=0.1, approach=None, max_cost=None,
+                thermodynamic='loopless', bigm=None):
     """ Reconstruct a metabolic model using the CarveMe approach.
 
     Args:
@@ -243,7 +244,8 @@ def carve_model(model, reaction_scores, inplace=True, default_score=-1.0, uptake
         from carveme.reconstruction.straindesign_backend import complete_model
         inactive = complete_model(model, reaction_scores, gprs=gprs, min_growth=min_growth,
                                   constraints=hard_constraints, solver=solver, threads=threads,
-                                  time_limit=time_limit, verbose=verbose)
+                                  time_limit=time_limit, verbose=verbose, approach=approach,
+                                  max_cost=max_cost, thermodynamic=thermodynamic, bigm=bigm)
         sol = None
     else:
         sol = minmax_reduction(model, scores, default_score=default_score, uptake_score=uptake_score, soft_score=soft_score,

--- a/carveme/reconstruction/gapfilling.py
+++ b/carveme/reconstruction/gapfilling.py
@@ -22,7 +22,8 @@ def gapFill(model, universe, constraints=None, min_growth=0.1, scores=None, inpl
         solver (Solver): solver instance (optional)
         tag (str): add a metadata tag to gapfilled reactions (optional)
         fast_gapfill (bool): use fast gapfilling algorithm (default: False)
-        backend (str): MILP backend, 'reframed' (default) or 'straindesign'
+        backend (str): MILP backend: 'reframed' (default), 'straindesign', or
+            'auto' to prefer StrainDesign when it is installed
     Returns:
         CBModel: gap filled model (if inplace=False)
 
@@ -42,6 +43,13 @@ def gapFill(model, universe, constraints=None, min_growth=0.1, scores=None, inpl
 
     if not scores:
         scores = {}
+
+    if backend == 'auto':
+        try:
+            import straindesign  # noqa: F401
+            backend = 'straindesign'
+        except ImportError:
+            backend = 'reframed'
 
     if backend == 'straindesign':
         from carveme.reconstruction.straindesign_backend import gapfill_straindesign

--- a/carveme/reconstruction/gapfilling.py
+++ b/carveme/reconstruction/gapfilling.py
@@ -7,7 +7,7 @@ from reframed import FBA
 
 
 def gapFill(model, universe, constraints=None, min_growth=0.1, scores=None, inplace=True, bigM=1e3, abstol=1e-9,
-            solver=None, tag=None, fast_gapfill=False):
+            solver=None, tag=None, fast_gapfill=False, backend='reframed'):
     """ Gap Fill a metabolic model by adding reactions from a reaction universe
 
     Args:
@@ -22,6 +22,7 @@ def gapFill(model, universe, constraints=None, min_growth=0.1, scores=None, inpl
         solver (Solver): solver instance (optional)
         tag (str): add a metadata tag to gapfilled reactions (optional)
         fast_gapfill (bool): use fast gapfilling algorithm (default: False)
+        backend (str): MILP backend, 'reframed' (default) or 'straindesign'
     Returns:
         CBModel: gap filled model (if inplace=False)
 
@@ -39,11 +40,20 @@ def gapFill(model, universe, constraints=None, min_growth=0.1, scores=None, inpl
         if r_id.startswith('R_EX'):
             model.set_flux_bounds(r_id, lb=0)
 
-    if not solver:
-        solver = solver_instance(model)
-
     if not scores:
         scores = {}
+
+    if backend == 'straindesign':
+        from carveme.reconstruction.straindesign_backend import gapfill_straindesign
+        added = gapfill_straindesign(model, new_reactions, scores=scores,
+                                     min_growth=min_growth, constraints=constraints)
+        inactive = [r_id for r_id in new_reactions if r_id not in added]
+        model.remove_reactions(inactive)
+        model.remove_metabolites(disconnected_metabolites(model))
+        return None if inplace else model
+
+    if not solver:
+        solver = solver_instance(model)
 
     if not hasattr(solver, '_gapfill_flag'):
         solver._gapfill_flag = True

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -218,9 +218,10 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
         min_growth (float): growth the completed model must reach
         min_atpm (float): maintenance flux the completed model must be able to carry
         constraints (dict): medium and other bound overrides
-        extra_conditions (list of dict): further media the model must also grow on. Each gets its
-            own flux system inside the same MILP, so a reaction shared by two conditions is paid
-            for once -- which iterated single-condition gap-filling does not achieve.
+        extra_conditions (list of dict): further media the model must also grow on. Each becomes
+            a PROTECT module over the same binaries, so every condition gets its own flux system
+            inside one MILP and a reaction shared by two of them is paid for once -- which
+            iterated single-condition gap-filling does not achieve.
         solver (str): MILP solver ('gurobi', 'cplex', 'scip', 'glpk')
         threads (int), time_limit (float), loopless (bool), verbose (bool)
 
@@ -228,7 +229,7 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
         set: reaction ids to REMOVE from the universe.
     """
     import straindesign as sd
-    from straindesign.names import COMPLETE
+    from straindesign.names import CARVEME, PROTECT, BEST
 
     score_of = dict(zip(reaction_scores['reaction'], reaction_scores['normalized_score']))
     gpr_of = dict(zip(reaction_scores['reaction'], reaction_scores.get('GPR', '')))
@@ -281,20 +282,25 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
               f'({len(duplicates)} reverse duplicates merged, {kept_apart} kept apart on '
               f'disjoint enzymes)')
 
-    module = sd.SDModule(cobra_model, COMPLETE, constraints=demands, core_reactions=core,
+    module = sd.SDModule(cobra_model, CARVEME, constraints=demands, core_reactions=core,
                          loopless=loopless, skip_checks=True)
-    kwargs = dict(ki_cost=ki_cost, compress=False)
+    # compression is off by default: on a universe it costs far more than it saves. It is a plain
+    # pipeline option here, not something this module type bypasses -- pass compress=True to use it.
+    kwargs = dict(ki_cost=ki_cost, compress=False, solution_approach=BEST, max_solutions=1,
+                  skip_preprocessing_fvas=True)
     if solver:
         kwargs['solver'] = solver
     if threads:
         kwargs['milp_threads'] = threads
     if time_limit:
         kwargs['time_limit'] = time_limit
-    if extra_conditions:
-        kwargs['extra_blocks'] = [demands + _bounds_to_constraints(cobra_model, cond)
-                                  for cond in extra_conditions]
+    modules = [module]
+    for condition in (extra_conditions or []):
+        modules.append(sd.SDModule(cobra_model, PROTECT, skip_checks=True,
+                                   constraints=demands + _bounds_to_constraints(cobra_model,
+                                                                                condition)))
 
-    solution = sd.compute_strain_designs(cobra_model, sd_modules=[module], **kwargs)
+    solution = sd.compute_strain_designs(cobra_model, sd_modules=modules, **kwargs)
     designs = solution.reaction_sd
     if not designs:
         raise RuntimeError('StrainDesign found no completion '
@@ -306,7 +312,9 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
                       f'valid -- every constraint holds -- but a cheaper one may exist. Raise '
                       f'time_limit to close the gap.')
 
-    bought = {r for r, kept in designs[0].items() if kept}
+    # read against the candidate list, not the design's keys: a candidate whose binary the MILP
+    # fixed to zero is reported in no design at all
+    bought = {r for r in candidates if designs[0].get(r)}
     inactive = (set(candidates) - bought) | duplicates
     if verbose:
         print(f'Completion kept {len(bought & annotated)}/{len(core)} annotated and bought '

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -195,7 +195,8 @@ def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
 def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
                    constraints=None, extra_conditions=None, solver=None, threads=None,
                    time_limit=None, thermodynamic='loopless', verbose=False, compress=None,
-                   skip_fvas=None, approach=None, seed=None, exchanges='prune'):
+                   skip_fvas=None, approach=None, seed=None, exchanges='prune',
+                   max_cost=None, bigm=1000.0):
     """Which reactions to leave out of the universe, chosen by completion instead of carving.
 
     Carving picks a threshold on annotation score and deletes below it, then repairs whatever
@@ -232,6 +233,17 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             first feasible one, which is far quicker and shows how much the search's arbitrary
             choices matter.
         seed (int): MILP seed, to sample alternative reconstructions of equal standing.
+        bigm (float): the constant M for gating rows whose bound is infinite. Defaults to 1e3,
+            the same value carving uses. Passing None leaves those rows as indicator constraints,
+            which is StrainDesign's default and is far slower here: an indicator contributes
+            nothing to the LP relaxation, so a formulation built from thousands of them starts
+            with almost no bound. Measured on E. coli -- indicators, over 10,817 s and no proof;
+            M = 1e3, 543 s and proven optimal, same reconstruction.
+
+            Sound only because StrainDesign pins the integrality tolerance (CPLEX 0, Gurobi and
+            SCIP 1e-9). At a solver's default of 1e-5 this same encoding leaks M x tol = 1e-2 of
+            flux through a reaction that reads as switched off -- which is how carving, using the
+            same M, ships reactions that cannot carry flux.
         exchanges (str): what to do with the universe's ~645 exchange reactions. 'prune' (default)
             keeps them out of the MILP and drops afterwards those whose metabolite no kept
             reaction touches. 'candidates' lets the MILP price them like anything else, which is
@@ -324,6 +336,14 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
     kwargs = dict(ki_cost=ki_cost, solution_approach=approach or BEST, max_solutions=1)
     if seed is not None:
         kwargs['seed'] = seed
+    if bigm is not None:
+        kwargs['M'] = bigm
+    if max_cost is not None:
+        # Bounds the total intervention cost. Since annotated reactions are priced negatively,
+        # a negative bound is a floor on how much annotation the result has to retain -- which is
+        # what makes approach='any' usable: without it the first feasible network satisfies growth
+        # and keeps almost none of the evidence.
+        kwargs['max_cost'] = max_cost
     if compress is not None:          # otherwise StrainDesign's CarveMe defaults apply
         kwargs['compress'] = compress
     if skip_fvas is not None:

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -1,4 +1,4 @@
-"""StrainDesign backend for gap-filling.
+"""StrainDesign backends for gap-filling and for carving.
 
 Gap-filling asks for the cheapest set of reactions to add from a universe so that the model
 grows. That is the same problem StrainDesign solves as a *knock-in* design: candidate
@@ -16,8 +16,12 @@ Two differences are the reason to try it. StrainDesign links binaries with **ind
 constraints** rather than a big-M, which removes the 1e3 bound as a source of numerical
 error; and it **compresses** the network first, which the default path does not do at all --
 on a model merged with a universe that is where the work is.
+
+The second entry point, :func:`complete_model`, replaces carving itself rather than the
+gap-filling that follows it. See its docstring for what changes.
 """
 
+import warnings
 from math import inf
 
 
@@ -120,3 +124,205 @@ def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, cons
 
     # a knock-in carries a positive value; anything else was not bought
     return {r_id for r_id, v in designs[0].items() if v > 0 and r_id in ki_cost}
+
+
+# ---------------------------------------------------------------------------------------------
+# Carving, posed as a completion
+# ---------------------------------------------------------------------------------------------
+
+SINK_COST = 50.0        # an artificial sink is a hole in the mass balance, not a reaction
+SPONT_COST = 0.1        # spontaneous chemistry needs no gene, so the genome cannot argue against it
+HET_COST = 1.0          # a reaction with no annotation support at all
+MIN_SCORE = 0.1         # floor on the reward, so a barely-supported hit is not free
+MIN_ATPM = 0.1          # maintenance demand the network must be able to meet
+EXTERNAL = 'C_e'
+
+
+def _spontaneous(gprs, reactions):
+    """Reactions whose only 'gene' is a spontaneity placeholder."""
+    if gprs is None:
+        return set()
+    is_spont = gprs.gene.astype(str).str.contains('s0001|SPONT', case=False, regex=True)
+    spont, catalysed = set(gprs[is_spont].reaction), set(gprs[~is_spont].reaction)
+    return (spont - catalysed) & set(reactions)
+
+
+def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
+    """Reactions that are the same chemistry written backwards.
+
+    BiGG carries many of these, and left alone they inflate the count of things the completion
+    can buy while adding no chemistry. Merging them is only safe when the two do not carry
+    *disjoint* enzyme evidence: two genuinely different enzymes running the same conversion in
+    opposite directions are two reactions, and collapsing them would erase one gene's support.
+    """
+    def signature(stoich, flip=False):
+        sign = -1 if flip else 1
+        return tuple(sorted((m, sign * v) for m, v in stoich.items()))
+
+    def genes_of(r_id):
+        import re
+        rule = gpr_of.get(r_id) or ''
+        return set(re.findall(r'[A-Za-z_][A-Za-z0-9_.\-]*', rule)) - {'and', 'or'}
+
+    forward = {}
+    for r_id, rxn in model.reactions.items():
+        if len(rxn.stoichiometry) >= 2:
+            forward.setdefault(signature(rxn.stoichiometry), []).append(r_id)
+
+    dropped, kept_apart = set(), 0
+    for r_id, rxn in model.reactions.items():
+        if len(rxn.stoichiometry) < 2 or r_id in dropped:
+            continue
+        for other in forward.get(signature(rxn.stoichiometry, flip=True), []):
+            if other == r_id or other in dropped:
+                continue
+            genes_a, genes_b = genes_of(r_id), genes_of(other)
+            if genes_a and genes_b and not (genes_a <= genes_b or genes_b <= genes_a):
+                kept_apart += 1
+                continue
+            # keep the annotated one, then the reversible one, so no evidence is lost
+            keep, gone = sorted((r_id, other),
+                                key=lambda x: (x in annotated, model.reactions[x].lb < 0, x),
+                                reverse=True)
+            dropped.add(gone)
+            if gone in annotated:
+                annotated.add(keep)
+                score_of[keep] = max(score_of.get(keep, 0.0), score_of.get(gone, 0.0))
+    return dropped, kept_apart
+
+
+def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
+                   constraints=None, extra_conditions=None, solver=None, threads=None,
+                   time_limit=None, loopless=True, verbose=False):
+    """Which reactions to leave out of the universe, chosen by completion instead of carving.
+
+    Carving picks a threshold on annotation score and deletes below it, then repairs whatever
+    broke. Nothing in that formulation ties a reaction's presence to its ability to carry flux,
+    so a draft model can contain reactions that can never run and can lose reactions the genome
+    plainly supports. Completion states both as constraints instead: an annotated reaction that
+    survives must demonstrably carry flux, and a reaction that was not bought carries none. The
+    result therefore has no blocked reactions, and the annotated reactions that could not be
+    connected at any price are named rather than silently dropped.
+
+    Costs follow CarveMe's own economics, so the two are comparable: an annotated reaction is
+    rewarded by its normalized score, an unannotated one costs 1. Two exceptions, both measured:
+    spontaneous reactions cost almost nothing, because no genome can be evidence against
+    chemistry that needs no enzyme; and artificial sinks cost 50, because a sink is a hole in the
+    mass balance that lets the network meet any demand without producing it. Pricing sinks like
+    ordinary reactions is what lets a completion satisfy biomass through a shortcut.
+
+    Args:
+        model (CBModel): universal model
+        reaction_scores (pandas.DataFrame): reaction scores, as `reaction_scoring` returns them
+        gprs (pandas.DataFrame): the BiGG GPR table, used to identify spontaneous reactions
+        min_growth (float): growth the completed model must reach
+        min_atpm (float): maintenance flux the completed model must be able to carry
+        constraints (dict): medium and other bound overrides
+        extra_conditions (list of dict): further media the model must also grow on. Each gets its
+            own flux system inside the same MILP, so a reaction shared by two conditions is paid
+            for once -- which iterated single-condition gap-filling does not achieve.
+        solver (str): MILP solver ('gurobi', 'cplex', 'scip', 'glpk')
+        threads (int), time_limit (float), loopless (bool), verbose (bool)
+
+    Returns:
+        set: reaction ids to REMOVE from the universe.
+    """
+    import straindesign as sd
+    from straindesign.names import COMPLETE
+
+    score_of = dict(zip(reaction_scores['reaction'], reaction_scores['normalized_score']))
+    gpr_of = dict(zip(reaction_scores['reaction'], reaction_scores.get('GPR', '')))
+    annotated = set(reaction_scores['reaction']) & set(model.reactions)
+
+    duplicates, kept_apart = _merge_reverse_duplicates(model, annotated, score_of, gpr_of)
+    spontaneous = _spontaneous(gprs, model.reactions)
+
+    cobra_model = _to_cobra(model, constraints)
+    biomass = model.biomass_reaction
+    atpm = next((r for r in ('R_ATPM', 'ATPM') if r in cobra_model.reactions), None)
+
+    # A merged duplicate is not something the completion may buy -- it is not in the universe.
+    # Its bounds are closed rather than the reaction deleted: this cobra model is built with a
+    # suppressed optlang problem, which cobra's remove_reactions reaches into and ours has no
+    # variables for. Excluded from the candidates below, it is inert either way.
+    from straindesign.networktools import suppress_lp_context
+    with suppress_lp_context(cobra_model):
+        for r_id in duplicates:
+            if r_id in cobra_model.reactions:
+                cobra_model.reactions.get_by_id(r_id).bounds = (0.0, 0.0)
+
+    exchange, sinks = set(), set()
+    for rxn in cobra_model.reactions:
+        if len(rxn.metabolites) != 1:
+            continue
+        (exchange if list(rxn.metabolites)[0].compartment == EXTERNAL else sinks).add(rxn.id)
+
+    fixed = exchange | duplicates | {biomass} | ({atpm} if atpm else set())
+    candidates = [r.id for r in cobra_model.reactions if r.id not in fixed]
+
+    def cost_of(r):
+        if r in sinks:
+            return SINK_COST
+        if r in annotated:
+            return -max(score_of.get(r, 1.0), MIN_SCORE)
+        if r in spontaneous:
+            return SPONT_COST
+        return HET_COST
+
+    ki_cost = {r: cost_of(r) for r in candidates}
+    core = [r for r in candidates if r in annotated]
+
+    demands = ['%s >= %g' % (biomass, min_growth)]
+    if atpm:
+        demands.append('%s >= %g' % (atpm, min_atpm))
+
+    if verbose:
+        print(f'Completion: {len(candidates)} candidates, {len(core)} annotated '
+              f'({len(duplicates)} reverse duplicates merged, {kept_apart} kept apart on '
+              f'disjoint enzymes)')
+
+    module = sd.SDModule(cobra_model, COMPLETE, constraints=demands, core_reactions=core,
+                         loopless=loopless, skip_checks=True)
+    kwargs = dict(ki_cost=ki_cost, compress=False)
+    if solver:
+        kwargs['solver'] = solver
+    if threads:
+        kwargs['milp_threads'] = threads
+    if time_limit:
+        kwargs['time_limit'] = time_limit
+    if extra_conditions:
+        kwargs['extra_blocks'] = [demands + _bounds_to_constraints(cobra_model, cond)
+                                  for cond in extra_conditions]
+
+    solution = sd.compute_strain_designs(cobra_model, sd_modules=[module], **kwargs)
+    designs = solution.reaction_sd
+    if not designs:
+        raise RuntimeError('StrainDesign found no completion '
+                           f'(status {getattr(solution, "status", "unknown")})')
+
+    status = getattr(solution, 'status', None)
+    if status != 'optimal':
+        warnings.warn(f'The completion did not prove optimality (status {status}). The model is '
+                      f'valid -- every constraint holds -- but a cheaper one may exist. Raise '
+                      f'time_limit to close the gap.')
+
+    bought = {r for r, kept in designs[0].items() if kept}
+    inactive = (set(candidates) - bought) | duplicates
+    if verbose:
+        print(f'Completion kept {len(bought & annotated)}/{len(core)} annotated and bought '
+              f'{len(bought - annotated)} unannotated reactions')
+    return inactive
+
+
+def _bounds_to_constraints(cobra_model, bounds):
+    """CarveMe writes media as {reaction: (lb, ub)}; a constraint block wants expressions."""
+    out = []
+    for r_id, bnd in (bounds or {}).items():
+        if r_id not in cobra_model.reactions:
+            continue
+        lo, hi = bnd if isinstance(bnd, (tuple, list)) else (bnd, bnd)
+        if lo is not None:
+            out.append('%s >= %g' % (r_id, lo))
+        if hi is not None:
+            out.append('%s <= %g' % (r_id, hi))
+    return out

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -193,8 +193,8 @@ def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
 
 def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
                    constraints=None, extra_conditions=None, solver=None, threads=None,
-                   time_limit=None, loopless=True, verbose=False, compress=False,
-                   skip_fvas=True):
+                   time_limit=None, thermodynamic='loopless', verbose=False, compress=None,
+                   skip_fvas=None):
     """Which reactions to leave out of the universe, chosen by completion instead of carving.
 
     Carving picks a threshold on annotation score and deletes below it, then repairs whatever
@@ -224,10 +224,13 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             inside one MILP and a reaction shared by two of them is paid for once -- which
             iterated single-condition gap-filling does not achieve.
         solver (str): MILP solver ('gurobi', 'cplex', 'scip', 'glpk')
-        threads (int), time_limit (float), loopless (bool), verbose (bool)
-        compress (bool or 'coupled'): StrainDesign's network compression. Off by default on a
-            universe; 'coupled' is a cheaper middle ground than full compression.
-        skip_fvas (bool): skip StrainDesign's preprocessing FVAs (default True)
+        threads (int), time_limit (float), verbose (bool)
+        thermodynamic (str): 'loopless' (default) forbids core reactions from satisfying their
+            must-run condition inside a thermodynamically infeasible cycle; None omits it.
+        compress, skip_fvas: StrainDesign pipeline options. Both default to off for a CarveMe
+            module -- on a universe there is little to compress and most of what an FVA scans
+            will not be bought. Note that coupled lumping sums knock-in costs, so
+            compress='coupled' is the harsh option here, not the gentle one.
 
     Returns:
         set: reaction ids to REMOVE from the universe.
@@ -287,14 +290,14 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
               f'disjoint enzymes)')
 
     module = sd.SDModule(cobra_model, CARVEME, constraints=demands, core_reactions=core,
-                         loopless=loopless, skip_checks=True)
+                         thermodynamic=thermodynamic, skip_checks=True)
     # compression is off by default: on a universe it costs far more than it saves. It is a plain
     # pipeline option here, not something this module type bypasses -- pass compress=True to use it.
-    # compress=False on a universe: there is little to compress and the attempt costs more than
-    # it saves. Both are plain pipeline options, not something this module type bypasses --
-    # compress='coupled' is the cheap middle ground if a run does want some reduction.
-    kwargs = dict(ki_cost=ki_cost, compress=compress, solution_approach=BEST, max_solutions=1,
-                  skip_preprocessing_fvas=skip_fvas)
+    kwargs = dict(ki_cost=ki_cost, solution_approach=BEST, max_solutions=1)
+    if compress is not None:          # otherwise StrainDesign's CarveMe defaults apply
+        kwargs['compress'] = compress
+    if skip_fvas is not None:
+        kwargs['skip_preprocessing_fvas'] = skip_fvas
     if solver:
         kwargs['solver'] = solver
     if threads:

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -30,14 +30,17 @@ def _to_cobra(model, constraints=None):
     """
     import cobra
     from reframed import to_cobrapy
-    from straindesign.networktools import suppress_lp_context
+    from straindesign.networktools import suppress_lp_context, set_suppressed_objective
 
     # Built inside StrainDesign's suppression context: cobra otherwise updates its optlang
     # problem on every metabolite, reaction and bound change, and nothing downstream reads it
-    # -- StrainDesign's FVA and compression build their own MILP_LP from the stoichiometry,
-    # and the module is created with skip_checks so its validation FBA never runs.
+    # -- StrainDesign's FVA and compression build their own MILP_LP from the stoichiometry.
     with suppress_lp_context(cobra.Model('shell')):
         out = to_cobrapy(model)
+        # to_cobrapy's `cb_model.objective = ...` writes into the optlang problem, which is
+        # suppressed here and has no variables to write to, so the objective would be dropped.
+        # Record it where StrainDesign reads it instead.
+        set_suppressed_objective(out, model.get_objective())
         for r_id, bounds in (constraints or {}).items():
             if r_id not in out.reactions:
                 continue

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -343,8 +343,18 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
     solution = sd.compute_strain_designs(cobra_model, sd_modules=modules, **kwargs)
     designs = solution.reaction_sd
     if not designs:
-        raise RuntimeError('StrainDesign found no completion '
-                           f'(status {getattr(solution, "status", "unknown")})')
+        status = getattr(solution, 'status', 'unknown')
+        detail = ''
+        if status == 'time_limit':
+            # A run that spends hours and then returns nothing is the worst outcome, so say what
+            # to change rather than only what happened. 'best' proves the cheapest reconstruction
+            # and at genome scale often cannot do so within any practical budget; 'any' returns a
+            # feasible one in a fraction of the time, at the cost of being one arbitrary pick.
+            detail = (". The search proved nothing within time_limit=%s. Raise it, or use "
+                      "approach='any' for a feasible reconstruction rather than the cheapest one. "
+                      "Note also that exchanges='candidates' adds a binary per exchange reaction "
+                      "and is markedly harder to solve than the default." % time_limit)
+        raise RuntimeError(f'StrainDesign found no completion (status {status}){detail}')
 
     status = getattr(solution, 'status', None)
     if status != 'optimal':

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -136,6 +136,11 @@ HET_COST = 1.0          # a reaction with no annotation support at all
 MIN_SCORE = 0.1         # floor on the reward, so a barely-supported hit is not free
 MIN_ATPM = 0.1          # maintenance demand the network must be able to meet
 EXTERNAL = 'C_e'
+# The universe gives reversible reactions infinite bounds, but CarveMe's own carving MILP gates
+# them with bigM = 1e3, so a flux beyond that is outside anything CarveMe models in the first
+# place. Adopting the same scale here keeps the two backends comparable and gives the must-run
+# conditions a finite value to relax to.
+FLUX_BOUND = 1000.0
 
 
 def _spontaneous(gprs, reactions):
@@ -193,7 +198,8 @@ def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
 
 def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
                    constraints=None, extra_conditions=None, solver=None, threads=None,
-                   time_limit=None, loopless=True, verbose=False):
+                   time_limit=None, loopless=True, verbose=False, compress=False,
+                   skip_fvas=True):
     """Which reactions to leave out of the universe, chosen by completion instead of carving.
 
     Carving picks a threshold on annotation score and deletes below it, then repairs whatever
@@ -224,6 +230,9 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             iterated single-condition gap-filling does not achieve.
         solver (str): MILP solver ('gurobi', 'cplex', 'scip', 'glpk')
         threads (int), time_limit (float), loopless (bool), verbose (bool)
+        compress (bool or 'coupled'): StrainDesign's network compression. Off by default on a
+            universe; 'coupled' is a cheaper middle ground than full compression.
+        skip_fvas (bool): skip StrainDesign's preprocessing FVAs (default True)
 
     Returns:
         set: reaction ids to REMOVE from the universe.
@@ -251,6 +260,8 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
         for r_id in duplicates:
             if r_id in cobra_model.reactions:
                 cobra_model.reactions.get_by_id(r_id).bounds = (0.0, 0.0)
+        for rxn in cobra_model.reactions:
+            rxn.bounds = (max(rxn.lower_bound, -FLUX_BOUND), min(rxn.upper_bound, FLUX_BOUND))
 
     exchange, sinks = set(), set()
     for rxn in cobra_model.reactions:
@@ -286,8 +297,11 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
                          loopless=loopless, skip_checks=True)
     # compression is off by default: on a universe it costs far more than it saves. It is a plain
     # pipeline option here, not something this module type bypasses -- pass compress=True to use it.
-    kwargs = dict(ki_cost=ki_cost, compress=False, solution_approach=BEST, max_solutions=1,
-                  skip_preprocessing_fvas=True)
+    # compress=False on a universe: there is little to compress and the attempt costs more than
+    # it saves. Both are plain pipeline options, not something this module type bypasses --
+    # compress='coupled' is the cheap middle ground if a run does want some reduction.
+    kwargs = dict(ki_cost=ki_cost, compress=compress, solution_approach=BEST, max_solutions=1,
+                  skip_preprocessing_fvas=skip_fvas)
     if solver:
         kwargs['solver'] = solver
     if threads:

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -132,6 +132,7 @@ def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, cons
 
 SINK_COST = 50.0        # an artificial sink is a hole in the mass balance, not a reaction
 SPONT_COST = 0.1        # spontaneous chemistry needs no gene, so the genome cannot argue against it
+EXCHANGE_COST = 0.1     # an exchange needs no gene either, but should not be free (see below)
 HET_COST = 1.0          # a reaction with no annotation support at all
 MIN_SCORE = 0.1         # floor on the reward, so a barely-supported hit is not free
 MIN_ATPM = 0.1          # maintenance demand the network must be able to meet
@@ -265,7 +266,13 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             continue
         (exchange if list(rxn.metabolites)[0].compartment == EXTERNAL else sinks).add(rxn.id)
 
-    fixed = exchange | duplicates | {biomass} | ({atpm} if atpm else set())
+    # Exchanges are candidates too, at a small price. Left out of the candidate set they can never
+    # be dropped, and the result then carries a transporter for every metabolite in the universe --
+    # 645 of them, nearly all unusable by the chemistry that was actually bought, and every one
+    # counted as blocked. Carving drops them for the same reason, so leaving them in would also
+    # make the two backends incomparable. The price has to be positive rather than zero: at zero
+    # an unusable exchange costs nothing to buy and the choice is arbitrary.
+    fixed = duplicates | {biomass} | ({atpm} if atpm else set())
     candidates = [r.id for r in cobra_model.reactions if r.id not in fixed]
 
     def cost_of(r):
@@ -273,6 +280,8 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             return SINK_COST
         if r in annotated:
             return -max(score_of.get(r, 1.0), MIN_SCORE)
+        if r in exchange:
+            return EXCHANGE_COST
         if r in spontaneous:
             return SPONT_COST
         return HET_COST

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -195,7 +195,7 @@ def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
 def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
                    constraints=None, extra_conditions=None, solver=None, threads=None,
                    time_limit=None, thermodynamic='loopless', verbose=False, compress=None,
-                   skip_fvas=None, approach=None, seed=None):
+                   skip_fvas=None, approach=None, seed=None, exchanges='prune'):
     """Which reactions to leave out of the universe, chosen by completion instead of carving.
 
     Carving picks a threshold on annotation score and deletes below it, then repairs whatever
@@ -232,6 +232,14 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
             first feasible one, which is far quicker and shows how much the search's arbitrary
             choices matter.
         seed (int): MILP seed, to sample alternative reconstructions of equal standing.
+        exchanges (str): what to do with the universe's ~645 exchange reactions. 'prune' (default)
+            keeps them out of the MILP and drops afterwards those whose metabolite no kept
+            reaction touches. 'candidates' lets the MILP price them like anything else, which is
+            what carving effectively does and yields a slightly smaller model -- but it adds a
+            binary each, and measurably so: with them the larger universes did not reach even a
+            first feasible solution in two hours, without them the same problems solve in minutes.
+            An exchange carries no gene evidence and no must-run condition, so which of the two is
+            used changes no claim the formulation makes.
         compress, skip_fvas: StrainDesign pipeline options. Both default to off for a CarveMe
             module -- on a universe there is little to compress and most of what an FVA scans
             will not be bought. Note that coupled lumping sums knock-in costs, so
@@ -282,6 +290,8 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
     # make the two backends incomparable. The price has to be positive rather than zero: at zero
     # an unusable exchange costs nothing to buy and the choice is arbitrary.
     fixed = duplicates | {biomass} | ({atpm} if atpm else set())
+    if exchanges == 'prune':
+        fixed |= exchange
     candidates = [r.id for r in cobra_model.reactions if r.id not in fixed]
 
     def cost_of(r):
@@ -346,6 +356,23 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
     # fixed to zero is reported in no design at all
     bought = {r for r in candidates if designs[0].get(r)}
     inactive = (set(candidates) - bought) | duplicates
+    if exchanges == 'prune':
+        # An exchange can only carry flux if something else in the kept network touches its
+        # metabolite. That is a structural fact, not a decision worth a binary, so it is settled
+        # here rather than in the MILP.
+        kept = {r.id for r in cobra_model.reactions} - inactive
+        touched = set()
+        for r_id in kept:
+            if r_id in exchange:
+                continue
+            touched.update(m.id for m in cobra_model.reactions.get_by_id(r_id).metabolites)
+        stranded = {r_id for r_id in exchange
+                    if not touched & {m.id for m in
+                                      cobra_model.reactions.get_by_id(r_id).metabolites}}
+        inactive |= stranded
+        if verbose:
+            print(f'Pruned {len(stranded)} exchange reactions whose metabolite nothing else '
+                  f'touches')
     if verbose:
         print(f'Completion kept {len(bought & annotated)}/{len(core)} annotated and bought '
               f'{len(bought - annotated)} unannotated reactions')

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -35,8 +35,20 @@ def _to_cobra(model, constraints=None):
     # Built inside StrainDesign's suppression context: cobra otherwise updates its optlang
     # problem on every metabolite, reaction and bound change, and nothing downstream reads it
     # -- StrainDesign's FVA and compression build their own MILP_LP from the stoichiometry.
+    # Gene rules are dropped for the conversion: gap-filling buys reactions, nothing here ever
+    # looks at a gene, and cobra parses every rule into a GPR tree on assignment -- 0.34 s to
+    # build them and another 0.25 s every time the model is copied. They are put back on the
+    # caller's model immediately, so this is invisible from the outside; blanking them first is
+    # what lets us keep using reframed's own converter instead of maintaining a second one.
+    gprs = {r_id: rxn.gpr for r_id, rxn in model.reactions.items()}
     with suppress_lp_context(cobra.Model('shell')):
-        out = to_cobrapy(model)
+        try:
+            for rxn in model.reactions.values():
+                rxn.gpr = None
+            out = to_cobrapy(model)
+        finally:
+            for r_id, gpr in gprs.items():
+                model.reactions[r_id].gpr = gpr
         # to_cobrapy's `cb_model.objective = ...` writes into the optlang problem, which is
         # suppressed here and has no variables to write to, so the objective would be dropped.
         # Record it where StrainDesign reads it instead.

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -136,11 +136,6 @@ HET_COST = 1.0          # a reaction with no annotation support at all
 MIN_SCORE = 0.1         # floor on the reward, so a barely-supported hit is not free
 MIN_ATPM = 0.1          # maintenance demand the network must be able to meet
 EXTERNAL = 'C_e'
-# The universe gives reversible reactions infinite bounds, but CarveMe's own carving MILP gates
-# them with bigM = 1e3, so a flux beyond that is outside anything CarveMe models in the first
-# place. Adopting the same scale here keeps the two backends comparable and gives the must-run
-# conditions a finite value to relax to.
-FLUX_BOUND = 1000.0
 
 
 def _spontaneous(gprs, reactions):
@@ -260,8 +255,6 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
         for r_id in duplicates:
             if r_id in cobra_model.reactions:
                 cobra_model.reactions.get_by_id(r_id).bounds = (0.0, 0.0)
-        for rxn in cobra_model.reactions:
-            rxn.bounds = (max(rxn.lower_bound, -FLUX_BOUND), min(rxn.upper_bound, FLUX_BOUND))
 
     exchange, sinks = set(), set()
     for rxn in cobra_model.reactions:

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -18,37 +18,28 @@ error; and it **compresses** the network first, which the default path does not 
 on a model merged with a universe that is where the work is.
 """
 
-from math import isinf
-
-
 def _to_cobra(model, constraints=None):
-    """Build a cobrapy model from a reframed CBModel.
+    """reframed's own converter, plus CarveMe's medium constraints.
 
-    Only stoichiometry and bounds are carried across: gap-filling needs nothing else, and
-    leaving genes behind keeps StrainDesign in its reaction-based mode.
+    `to_cobrapy` already carries stoichiometry, bounds, GPRs and the objective across, so
+    there is no reason to reimplement it -- using theirs also means we track their model
+    semantics instead of drifting from them.
     """
-    from cobra import Model, Metabolite, Reaction
+    from reframed import to_cobrapy
 
-    out = Model('gapfill')
-    out.add_metabolites([Metabolite(m_id) for m_id in model.metabolites])
-    mets = {m.id: m for m in out.metabolites}
-
-    reactions = []
-    for r_id, rxn in model.reactions.items():
-        r = Reaction(r_id)
-        lb, ub = float(rxn.lb), float(rxn.ub)
-        if constraints and r_id in constraints:
-            bounds = constraints[r_id]
-            if isinstance(bounds, (tuple, list)):
-                lb, ub = float(bounds[0]), float(bounds[1])
-            else:                                    # a single value fixes the flux
-                lb = ub = float(bounds)
-        r.lower_bound, r.upper_bound = lb, ub
-        reactions.append((r, rxn))
-    out.add_reactions([r for r, _ in reactions])
-    for r, rxn in reactions:
-        out.reactions.get_by_id(r.id).add_metabolites(
-            {mets[m_id]: float(coeff) for m_id, coeff in rxn.stoichiometry.items()})
+    # Note: this builds an optlang problem that StrainDesign never touches -- its FVA and
+    # compression construct their own MILP_LP straight from the stoichiometry, and it keeps
+    # cobra's solver suppressed throughout. On a universe-sized model the conversion costs
+    # ~3.5 s for 5532 reactions, so it is worth revisiting if it ever dominates.
+    out = to_cobrapy(model)
+    for r_id, bounds in (constraints or {}).items():
+        if r_id not in out.reactions:
+            continue
+        rxn = out.reactions.get_by_id(r_id)
+        if isinstance(bounds, (tuple, list)):
+            rxn.bounds = (float(bounds[0]), float(bounds[1]))
+        else:                                        # a single value fixes the flux
+            rxn.bounds = (float(bounds), float(bounds))
     return out
 
 

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -18,6 +18,9 @@ error; and it **compresses** the network first, which the default path does not 
 on a model merged with a universe that is where the work is.
 """
 
+from math import inf
+
+
 def _to_cobra(model, constraints=None):
     """reframed's own converter, plus CarveMe's medium constraints.
 
@@ -25,26 +28,32 @@ def _to_cobra(model, constraints=None):
     there is no reason to reimplement it -- using theirs also means we track their model
     semantics instead of drifting from them.
     """
+    import cobra
     from reframed import to_cobrapy
+    from straindesign.networktools import suppress_lp_context
 
-    # Note: this builds an optlang problem that StrainDesign never touches -- its FVA and
-    # compression construct their own MILP_LP straight from the stoichiometry, and it keeps
-    # cobra's solver suppressed throughout. On a universe-sized model the conversion costs
-    # ~3.5 s for 5532 reactions, so it is worth revisiting if it ever dominates.
-    out = to_cobrapy(model)
-    for r_id, bounds in (constraints or {}).items():
-        if r_id not in out.reactions:
-            continue
-        rxn = out.reactions.get_by_id(r_id)
-        if isinstance(bounds, (tuple, list)):
-            rxn.bounds = (float(bounds[0]), float(bounds[1]))
-        else:                                        # a single value fixes the flux
-            rxn.bounds = (float(bounds), float(bounds))
+    # Built inside StrainDesign's suppression context: cobra otherwise updates its optlang
+    # problem on every metabolite, reaction and bound change, and nothing downstream reads it
+    # -- StrainDesign's FVA and compression build their own MILP_LP from the stoichiometry,
+    # and the module is created with skip_checks so its validation FBA never runs.
+    with suppress_lp_context(cobra.Model('shell')):
+        out = to_cobrapy(model)
+        for r_id, bounds in (constraints or {}).items():
+            if r_id not in out.reactions:
+                continue
+            rxn = out.reactions.get_by_id(r_id)
+            if isinstance(bounds, (tuple, list)):
+                # multiGapFill writes bounds like (-max_uptake, None); None means unbounded
+                lo, hi = bounds
+                rxn.bounds = (-inf if lo is None else float(lo),
+                              inf if hi is None else float(hi))
+            else:                                    # a single value fixes the flux
+                rxn.bounds = (float(bounds), float(bounds))
     return out
 
 
 def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, constraints=None,
-                         solver=None, time_limit=None):
+                         solver=None, time_limit=None, compress=False, skip_fvas=True):
     """Cheapest set of candidates to add so the model grows.
 
     Args:
@@ -55,6 +64,9 @@ def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, cons
         constraints (dict): medium and other bound overrides
         solver (str): MILP solver for StrainDesign ('gurobi', 'cplex', 'scip', 'glpk')
         time_limit (float): seconds, optional
+        compress (bool): run StrainDesign's network compression (default False)
+        skip_fvas (bool): skip StrainDesign's preprocessing FVAs (default True) -- they
+            narrow the problem for the MILP, which gap-filling does not need
 
     Returns:
         set: the candidates that must be ADDED. Everything else in `new_reactions` is
@@ -69,14 +81,21 @@ def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, cons
     biomass = model.biomass_reaction
     ki_cost = {r_id: 1.0 / (1.0 + scores.get(r_id, 0.0)) for r_id in new_reactions}
 
-    kwargs = dict(compress=True, solution_approach='best', max_solutions=1,
-                  ki_cost=ki_cost)
+    # compression is off by default: on a model merged with a universe it costs far more
+    # than it saves -- measured 308 s against 0.9 s for the default backend on a gap-fill
+    # that adds nothing at all
+    kwargs = dict(compress=compress, solution_approach='best', max_solutions=1,
+                  ki_cost=ki_cost, skip_preprocessing_fvas=skip_fvas)
     if solver:
         kwargs['solver'] = solver
     if time_limit:
         kwargs['time_limit'] = time_limit
 
-    module = SDModule(cobra_model, 'protect', constraints=[f'{biomass} >= {min_growth}'])
+    # skip_checks: the module's feasibility FBA reads objective coefficients one reaction at
+    # a time through cobra's optlang problem, which is the only thing here that needs a live
+    # cobra solver. Gap-filling has already established the model is the one we built.
+    module = SDModule(cobra_model, 'protect', constraints=[f'{biomass} >= {min_growth}'],
+                      skip_checks=True)
     solution = compute_strain_designs(cobra_model, sd_modules=[module], **kwargs)
 
     designs = solution.get_reaction_sd() if hasattr(solution, 'get_reaction_sd') else solution.reaction_sd

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -1,0 +1,97 @@
+"""StrainDesign backend for gap-filling.
+
+Gap-filling asks for the cheapest set of reactions to add from a universe so that the model
+grows. That is the same problem StrainDesign solves as a *knock-in* design: candidate
+reactions are absent until bought, each carries a cost, and a PROTECT module states the
+behaviour that must remain feasible.
+
+    reframed / default backend            StrainDesign backend
+    ----------------------------------    --------------------------------------
+    y_r in {0,1} per candidate            knock-in candidate (inverted binary)
+    v_r linked to y_r by bigM (1e3)       indicator constraint
+    biomass >= min_growth                 PROTECT module
+    min sum 1/(1+score_r) * y_r           ki_cost[r] = 1/(1+score_r)
+
+Two differences are the reason to try it. StrainDesign links binaries with **indicator
+constraints** rather than a big-M, which removes the 1e3 bound as a source of numerical
+error; and it **compresses** the network first, which the default path does not do at all --
+on a model merged with a universe that is where the work is.
+"""
+
+from math import isinf
+
+
+def _to_cobra(model, constraints=None):
+    """Build a cobrapy model from a reframed CBModel.
+
+    Only stoichiometry and bounds are carried across: gap-filling needs nothing else, and
+    leaving genes behind keeps StrainDesign in its reaction-based mode.
+    """
+    from cobra import Model, Metabolite, Reaction
+
+    out = Model('gapfill')
+    out.add_metabolites([Metabolite(m_id) for m_id in model.metabolites])
+    mets = {m.id: m for m in out.metabolites}
+
+    reactions = []
+    for r_id, rxn in model.reactions.items():
+        r = Reaction(r_id)
+        lb, ub = float(rxn.lb), float(rxn.ub)
+        if constraints and r_id in constraints:
+            bounds = constraints[r_id]
+            if isinstance(bounds, (tuple, list)):
+                lb, ub = float(bounds[0]), float(bounds[1])
+            else:                                    # a single value fixes the flux
+                lb = ub = float(bounds)
+        r.lower_bound, r.upper_bound = lb, ub
+        reactions.append((r, rxn))
+    out.add_reactions([r for r, _ in reactions])
+    for r, rxn in reactions:
+        out.reactions.get_by_id(r.id).add_metabolites(
+            {mets[m_id]: float(coeff) for m_id, coeff in rxn.stoichiometry.items()})
+    return out
+
+
+def gapfill_straindesign(model, new_reactions, scores=None, min_growth=0.1, constraints=None,
+                         solver=None, time_limit=None):
+    """Cheapest set of candidates to add so the model grows.
+
+    Args:
+        model (CBModel): merged model (original plus universe)
+        new_reactions (iterable): candidate reaction ids, absent until bought
+        scores (dict): reaction scores; penalty is 1/(1+score), as in the default backend
+        min_growth (float): growth the gap-filled model must reach
+        constraints (dict): medium and other bound overrides
+        solver (str): MILP solver for StrainDesign ('gurobi', 'cplex', 'scip', 'glpk')
+        time_limit (float): seconds, optional
+
+    Returns:
+        set: the candidates that must be ADDED. Everything else in `new_reactions` is
+        inactive and gets removed by the caller.
+    """
+    from straindesign import SDModule, compute_strain_designs
+
+    scores = scores or {}
+    new_reactions = list(new_reactions)
+    cobra_model = _to_cobra(model, constraints)
+
+    biomass = model.biomass_reaction
+    ki_cost = {r_id: 1.0 / (1.0 + scores.get(r_id, 0.0)) for r_id in new_reactions}
+
+    kwargs = dict(compress=True, solution_approach='best', max_solutions=1,
+                  ki_cost=ki_cost)
+    if solver:
+        kwargs['solver'] = solver
+    if time_limit:
+        kwargs['time_limit'] = time_limit
+
+    module = SDModule(cobra_model, 'protect', constraints=[f'{biomass} >= {min_growth}'])
+    solution = compute_strain_designs(cobra_model, sd_modules=[module], **kwargs)
+
+    designs = solution.get_reaction_sd() if hasattr(solution, 'get_reaction_sd') else solution.reaction_sd
+    if not designs:
+        raise RuntimeError('StrainDesign found no gap-filling solution '
+                           f'(status {getattr(solution, "status", "unknown")})')
+
+    # a knock-in carries a positive value; anything else was not bought
+    return {r_id for r_id, v in designs[0].items() if v > 0 and r_id in ki_cost}

--- a/carveme/reconstruction/straindesign_backend.py
+++ b/carveme/reconstruction/straindesign_backend.py
@@ -195,7 +195,7 @@ def _merge_reverse_duplicates(model, annotated, score_of, gpr_of):
 def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=MIN_ATPM,
                    constraints=None, extra_conditions=None, solver=None, threads=None,
                    time_limit=None, thermodynamic='loopless', verbose=False, compress=None,
-                   skip_fvas=None):
+                   skip_fvas=None, approach=None, seed=None):
     """Which reactions to leave out of the universe, chosen by completion instead of carving.
 
     Carving picks a threshold on annotation score and deletes below it, then repairs whatever
@@ -228,6 +228,10 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
         threads (int), time_limit (float), verbose (bool)
         thermodynamic (str): 'loopless' (default) forbids core reactions from satisfying their
             must-run condition inside a thermodynamically infeasible cycle; None omits it.
+        approach (str): 'best' (default) proves the cheapest reconstruction; 'any' returns the
+            first feasible one, which is far quicker and shows how much the search's arbitrary
+            choices matter.
+        seed (int): MILP seed, to sample alternative reconstructions of equal standing.
         compress, skip_fvas: StrainDesign pipeline options. Both default to off for a CarveMe
             module -- on a universe there is little to compress and most of what an FVA scans
             will not be bought. Note that coupled lumping sums knock-in costs, so
@@ -240,7 +244,12 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
     from straindesign.names import CARVEME, PROTECT, BEST
 
     score_of = dict(zip(reaction_scores['reaction'], reaction_scores['normalized_score']))
-    gpr_of = dict(zip(reaction_scores['reaction'], reaction_scores.get('GPR', '')))
+    if 'GPR' not in reaction_scores:
+        # Without rules there is no enzyme evidence to compare, and the disjoint-enzyme exception
+        # below would quietly never fire -- merging reverse duplicates that should stay apart.
+        raise ValueError('reaction_scores has no GPR column, so reverse duplicates cannot be '
+                         'merged safely. Pass the frame reaction_scoring returns.')
+    gpr_of = dict(zip(reaction_scores['reaction'], reaction_scores['GPR']))
     annotated = set(reaction_scores['reaction']) & set(model.reactions)
 
     duplicates, kept_apart = _merge_reverse_duplicates(model, annotated, score_of, gpr_of)
@@ -302,7 +311,9 @@ def complete_model(model, reaction_scores, gprs=None, min_growth=0.1, min_atpm=M
                          thermodynamic=thermodynamic, skip_checks=True)
     # compression is off by default: on a universe it costs far more than it saves. It is a plain
     # pipeline option here, not something this module type bypasses -- pass compress=True to use it.
-    kwargs = dict(ki_cost=ki_cost, solution_approach=BEST, max_solutions=1)
+    kwargs = dict(ki_cost=ki_cost, solution_approach=approach or BEST, max_solutions=1)
+    if seed is not None:
+        kwargs['seed'] = seed
     if compress is not None:          # otherwise StrainDesign's CarveMe defaults apply
         kwargs['compress'] = compress
     if skip_fvas is not None:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -172,3 +172,39 @@ Please use *hard* constraints with care, as they can make the reconstruction pro
 
 
 
+
+Reconstruction by completion
+----------------------------
+
+By default CarveMe reconstructs by *carving*: it takes the universal network, scores every reaction
+by how well the genome supports it, and deletes the low scorers until what remains still grows.
+Nothing in that formulation ties a reaction's presence to its ability to carry flux, so a draft
+model can end up containing reactions that can never run, and missing reactions the genome plainly
+supports.
+
+The ``straindesign`` backend poses the same problem the other way round. It starts from the
+annotated core and buys the cheapest additions that let that core run, stating both properties as
+constraints:
+
+* a reaction that was not bought carries no flux, and
+* an annotated reaction that *was* kept demonstrably carries flux.
+
+Together these mean the reconstructed model contains no blocked reactions at all -- not because
+they were cleaned up afterwards, but because no other solution is feasible. Annotated reactions
+that could not be connected at any price are reported by name instead of disappearing quietly.
+
+.. code-block:: console
+
+    $ carve genome.faa --backend straindesign --solver cplex
+
+The costs are CarveMe's own, so the two backends are comparable: an annotated reaction is rewarded
+by its normalized score and an unannotated one costs 1. There are two exceptions. Spontaneous
+reactions cost almost nothing, because a genome cannot be evidence against chemistry that needs no
+enzyme. Artificial sinks cost 50, because a sink is a hole in the mass balance rather than a
+reaction -- priced like anything else, it lets the network meet the biomass demand through a
+shortcut instead of producing the metabolite.
+
+This backend requires `StrainDesign <https://straindesign.readthedocs.io>`_ and a MILP solver
+(CPLEX, Gurobi, SCIP or GLPK). It is slower than carving -- minutes rather than seconds at
+genome scale -- because it solves one MILP over the whole universe instead of a sequence of
+smaller ones. Pass ``--solver`` to choose the solver.

--- a/prof_sd.py
+++ b/prof_sd.py
@@ -1,0 +1,17 @@
+import warnings, logging, time
+warnings.filterwarnings('ignore')
+logging.basicConfig(level=logging.INFO, format='%(message)s', force=True)
+from reframed import load_cbmodel
+from reframed.core.environment import Environment
+from carveme.reconstruction.gapfilling import merge_models
+from carveme.reconstruction.straindesign_backend import gapfill_straindesign
+
+m = load_cbmodel('carveme/data/benchmark/models/ecol.xml', flavor='bigg')
+u = load_cbmodel('carveme/data/generated/universe_bacteria.xml.gz', flavor='bigg')
+new = set(u.reactions) - set(m.reactions)
+merged = merge_models(m, u, inplace=False)
+constr = dict(Environment.from_compounds(
+    ['glc__D','o2','nh4','pi','so4','h2o','h','k','mg2','fe2','ca2','cl','na1'], max_uptake=10))
+t0 = time.time()
+added = gapfill_straindesign(merged, new, scores={}, min_growth=0.05, constraints=constr, compress=False)
+print(f'TOTAL {time.time()-t0:.1f}s added={len(added)}', flush=True)

--- a/prof_sd2.py
+++ b/prof_sd2.py
@@ -1,0 +1,20 @@
+import warnings, logging, cProfile, pstats, io, time
+warnings.filterwarnings('ignore'); logging.disable(logging.WARNING)
+from reframed import load_cbmodel
+from reframed.core.environment import Environment
+from carveme.reconstruction.gapfilling import merge_models
+from carveme.reconstruction.straindesign_backend import gapfill_straindesign
+
+m = load_cbmodel('carveme/data/benchmark/models/ecol.xml', flavor='bigg')
+u = load_cbmodel('carveme/data/generated/universe_bacteria.xml.gz', flavor='bigg')
+new = set(u.reactions) - set(m.reactions)
+merged = merge_models(m, u, inplace=False)
+constr = dict(Environment.from_compounds(
+    ['glc__D','o2','nh4','pi','so4','h2o','h','k','mg2','fe2','ca2','cl','na1'], max_uptake=10))
+
+pr = cProfile.Profile(); pr.enable(); t0 = time.time()
+gapfill_straindesign(merged, new, scores={}, min_growth=0.05, constraints=constr, compress=False, skip_fvas=True)
+wall = time.time() - t0; pr.disable()
+s = io.StringIO(); ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
+ps.print_stats(24)
+print(f'WALL {wall:.1f}s'); print(s.getvalue())


### PR DESCRIPTION
gapFill's MILP is a knock-in design: candidates absent until bought, a cost per candidate, and a growth requirement that must stay feasible. StrainDesign expresses that directly, so the backend is a translation rather than a reimplementation -- ki_cost = 1/(1+score) and a PROTECT module on biomass.

Two reasons to offer it: binaries are linked by indicator constraints instead of a big-M of 1e3, removing that bound as a source of numerical error; and the network is compressed first, which the default path does not do at all and which is where the work sits once a universe has been merged in.

Opt-in via backend='straindesign'; the default path is untouched.